### PR TITLE
fix: arm64 support

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -12,6 +12,12 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
     - name: Log in to the Container registry
       uses: docker/login-action@v3
       with:
@@ -30,6 +36,7 @@ runs:
       uses: docker/build-push-action@v6
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: ${{ inputs.publish }}
         tags: ${{ steps.meta.outputs.tags }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,70 +2,53 @@
 ARG LAZYMC_VERSION=0.2.11
 ARG LAZYMC_LEGACY_VERSION=0.2.10
 
-# build lazymc
-FROM --platform=$BUILDPLATFORM rust:1.82 as lazymc-builder
+# set up rust
+FROM --platform=$BUILDPLATFORM rust:1.82 AS rust-setup
 ARG TARGETARCH
-ARG RUST_ARCH_AMD=${TARGETARCH/amd64/x86_64-unknown-linux-musl}
-ARG RUST_ARCH=${RUST_ARCH_AMD/arm64/aarch64-unknown-linux-musl}
-RUN rustup target add $RUST_ARCH
+RUN <<EOF
+  echo Running build for $TARGETARCH
+  if [ "$TARGETARCH" = "amd64" ]; then
+    echo x86_64-unknown-linux-musl > /rust-arch
+  elif [ "$TARGETARCH" = "arm64" ]; then
+    echo aarch64-unknown-linux-musl > /rust-arch
+    mkdir -p /.cargo/
+    echo [target.aarch64-unknown-linux-musl] >> /.cargo/config.toml
+    echo linker = \"aarch64-linux-gnu-gcc\" >> /.cargo/config.toml
+  fi
+EOF
+RUN rustup target add "$(cat /rust-arch)"
 RUN apt update && apt install -y musl-tools musl-dev
 RUN update-ca-certificates
 RUN apt-get update && apt-get install -y pkg-config libssl-dev crossbuild-essential-arm64 crossbuild-essential-armhf
+
+# build lazymc
+FROM --platform=$BUILDPLATFORM rust-setup AS lazymc-builder
 WORKDIR /usr/src/lazymc
 ARG LAZYMC_VERSION
 ENV LAZYMC_VERSION=$LAZYMC_VERSION
 RUN git clone --branch v$LAZYMC_VERSION https://github.com/timvisee/lazymc .
-RUN <<EOF
-  mkdir -p ./.cargo/
-  echo [target.aarch64-unknown-linux-musl] >> ./.cargo/config.toml
-  echo linker = \"aarch64-linux-gnu-gcc\" >> ./.cargo/config.toml
-EOF
-RUN cargo build --target $RUST_ARCH --release --locked
-RUN mv /usr/src/lazymc/target/$RUST_ARCH /usr/src/lazymc/target/output_final
+RUN cargo build --target "$(cat /rust-arch)" --release --locked
+RUN mv /usr/src/lazymc/target/"$(cat /rust-arch)" /usr/src/lazymc/target/output_final
 
 # build lazymc-legacy
-FROM --platform=$BUILDPLATFORM rust:1.82 as lazymc-legacy-builder
-ARG TARGETARCH
-ARG RUST_ARCH_AMD=${TARGETARCH/amd64/x86_64-unknown-linux-musl}
-ARG RUST_ARCH=${RUST_ARCH_AMD/arm64/aarch64-unknown-linux-musl}
-RUN rustup target add $RUST_ARCH
-RUN apt update && apt install -y musl-tools musl-dev
-RUN update-ca-certificates
-RUN apt-get update && apt-get install -y pkg-config libssl-dev crossbuild-essential-arm64 crossbuild-essential-armhf
+FROM --platform=$BUILDPLATFORM rust-setup AS lazymc-legacy-builder
 WORKDIR /usr/src/lazymc
 ARG LAZYMC_LEGACY_VERSION
 ENV LAZYMC_LEGACY_VERSION=$LAZYMC_LEGACY_VERSION
 RUN git clone --branch v$LAZYMC_LEGACY_VERSION https://github.com/timvisee/lazymc .
-RUN <<EOF
-  mkdir -p ./.cargo/
-  echo [target.aarch64-unknown-linux-musl] >> ./.cargo/config.toml
-  echo linker = \"aarch64-linux-gnu-gcc\" >> ./.cargo/config.toml
-EOF
-RUN cargo build --target $RUST_ARCH --release --locked
-RUN mv /usr/src/lazymc/target/$RUST_ARCH /usr/src/lazymc/target/output_final
+RUN cargo build --target "$(cat /rust-arch)" --release --locked
+RUN mv /usr/src/lazymc/target/"$(cat /rust-arch)" /usr/src/lazymc/target/output_final
 
 # build this app
-FROM --platform=$BUILDPLATFORM rust:1.82 as app-builder
-ARG TARGETARCH
-ARG RUST_ARCH_AMD=${TARGETARCH/amd64/x86_64-unknown-linux-musl}
-ARG RUST_ARCH=${RUST_ARCH_AMD/arm64/aarch64-unknown-linux-musl}
-RUN rustup target add $RUST_ARCH
-RUN apt update && apt install -y musl-tools musl-dev
-RUN update-ca-certificates
-RUN apt-get update && apt-get install -y pkg-config libssl-dev crossbuild-essential-arm64 crossbuild-essential-armhf
+FROM --platform=$BUILDPLATFORM rust-setup AS app-builder
 WORKDIR /usr/src/lazymc-docker-proxy
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN <<EOF
-  mkdir -p ./.cargo/
-  echo [target.aarch64-unknown-linux-musl] >> ./.cargo/config.toml
-  echo linker = \"aarch64-linux-gnu-gcc\" >> ./.cargo/config.toml
-EOF
-RUN cargo build --target $RUST_ARCH --release --locked
-RUN mv /usr/src/lazymc-docker-proxy/target/$RUST_ARCH /usr/src/lazymc-docker-proxy/target/output_final
+RUN cargo build --target "$(cat /rust-arch)" --release --locked
+RUN mv /usr/src/lazymc-docker-proxy/target/"$(cat /rust-arch)" /usr/src/lazymc-docker-proxy/target/output_final
 
 # health init
-FROM --platform=$BUILDPLATFORM busybox:1.37.0-uclibc as health-init
+FROM --platform=$BUILDPLATFORM busybox:1.37.0-uclibc AS health-init
 RUN mkdir -p /app && echo "STARTING" > /app/health
 
 # final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,42 +3,69 @@ ARG LAZYMC_VERSION=0.2.11
 ARG LAZYMC_LEGACY_VERSION=0.2.10
 
 # build lazymc
-FROM rust:1.82 as lazymc-builder
-RUN rustup target add x86_64-unknown-linux-musl
+FROM --platform=$BUILDPLATFORM rust:1.82 as lazymc-builder
+ARG TARGETARCH
+ARG RUST_ARCH_AMD=${TARGETARCH/amd64/x86_64-unknown-linux-musl}
+ARG RUST_ARCH=${RUST_ARCH_AMD/arm64/aarch64-unknown-linux-musl}
+RUN rustup target add $RUST_ARCH
 RUN apt update && apt install -y musl-tools musl-dev
 RUN update-ca-certificates
-RUN apt-get update && apt-get install -y pkg-config libssl-dev
+RUN apt-get update && apt-get install -y pkg-config libssl-dev crossbuild-essential-arm64 crossbuild-essential-armhf
 WORKDIR /usr/src/lazymc
 ARG LAZYMC_VERSION
 ENV LAZYMC_VERSION=$LAZYMC_VERSION
 RUN git clone --branch v$LAZYMC_VERSION https://github.com/timvisee/lazymc .
-RUN cargo build --target x86_64-unknown-linux-musl --release --locked
+RUN <<EOF
+  mkdir -p ./.cargo/
+  echo [target.aarch64-unknown-linux-musl] >> ./.cargo/config.toml
+  echo linker = \"aarch64-linux-gnu-gcc\" >> ./.cargo/config.toml
+EOF
+RUN cargo build --target $RUST_ARCH --release --locked
+RUN mv /usr/src/lazymc/target/$RUST_ARCH /usr/src/lazymc/target/output_final
 
 # build lazymc-legacy
-FROM rust:1.82 as lazymc-legacy-builder
-RUN rustup target add x86_64-unknown-linux-musl
+FROM --platform=$BUILDPLATFORM rust:1.82 as lazymc-legacy-builder
+ARG TARGETARCH
+ARG RUST_ARCH_AMD=${TARGETARCH/amd64/x86_64-unknown-linux-musl}
+ARG RUST_ARCH=${RUST_ARCH_AMD/arm64/aarch64-unknown-linux-musl}
+RUN rustup target add $RUST_ARCH
 RUN apt update && apt install -y musl-tools musl-dev
 RUN update-ca-certificates
-RUN apt-get update && apt-get install -y pkg-config libssl-dev
+RUN apt-get update && apt-get install -y pkg-config libssl-dev crossbuild-essential-arm64 crossbuild-essential-armhf
 WORKDIR /usr/src/lazymc
 ARG LAZYMC_LEGACY_VERSION
 ENV LAZYMC_LEGACY_VERSION=$LAZYMC_LEGACY_VERSION
 RUN git clone --branch v$LAZYMC_LEGACY_VERSION https://github.com/timvisee/lazymc .
-RUN cargo build --target x86_64-unknown-linux-musl --release --locked
+RUN <<EOF
+  mkdir -p ./.cargo/
+  echo [target.aarch64-unknown-linux-musl] >> ./.cargo/config.toml
+  echo linker = \"aarch64-linux-gnu-gcc\" >> ./.cargo/config.toml
+EOF
+RUN cargo build --target $RUST_ARCH --release --locked
+RUN mv /usr/src/lazymc/target/$RUST_ARCH /usr/src/lazymc/target/output_final
 
 # build this app
-FROM rust:1.82 as app-builder
-RUN rustup target add x86_64-unknown-linux-musl
+FROM --platform=$BUILDPLATFORM rust:1.82 as app-builder
+ARG TARGETARCH
+ARG RUST_ARCH_AMD=${TARGETARCH/amd64/x86_64-unknown-linux-musl}
+ARG RUST_ARCH=${RUST_ARCH_AMD/arm64/aarch64-unknown-linux-musl}
+RUN rustup target add $RUST_ARCH
 RUN apt update && apt install -y musl-tools musl-dev
 RUN update-ca-certificates
-RUN apt-get update && apt-get install -y pkg-config libssl-dev
+RUN apt-get update && apt-get install -y pkg-config libssl-dev crossbuild-essential-arm64 crossbuild-essential-armhf
 WORKDIR /usr/src/lazymc-docker-proxy
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN cargo build --target x86_64-unknown-linux-musl --release --locked
+RUN <<EOF
+  mkdir -p ./.cargo/
+  echo [target.aarch64-unknown-linux-musl] >> ./.cargo/config.toml
+  echo linker = \"aarch64-linux-gnu-gcc\" >> ./.cargo/config.toml
+EOF
+RUN cargo build --target $RUST_ARCH --release --locked
+RUN mv /usr/src/lazymc-docker-proxy/target/$RUST_ARCH /usr/src/lazymc-docker-proxy/target/output_final
 
 # health init
-FROM busybox:1.37.0-uclibc as health-init
+FROM --platform=$BUILDPLATFORM busybox:1.37.0-uclibc as health-init
 RUN mkdir -p /app && echo "STARTING" > /app/health
 
 # final image
@@ -51,13 +78,13 @@ ARG LAZYMC_LEGACY_VERSION
 ENV LAZYMC_LEGACY_VERSION=$LAZYMC_LEGACY_VERSION
 
 # Copy the compiled binary from the lazymc-builder stage
-COPY --from=lazymc-builder /usr/src/lazymc/target/x86_64-unknown-linux-musl/release/lazymc /usr/local/bin/lazymc
+COPY --from=lazymc-builder /usr/src/lazymc/target/output_final/release/lazymc /usr/local/bin/lazymc
 
 # Copy the compiled binary from the lazymc-legacy-builder stage
-COPY --from=lazymc-legacy-builder /usr/src/lazymc/target/x86_64-unknown-linux-musl/release/lazymc /usr/local/bin/lazymc-legacy
+COPY --from=lazymc-legacy-builder /usr/src/lazymc/target/output_final/release/lazymc /usr/local/bin/lazymc-legacy
 
 # Copy the compiled binary from the lazymc-docker-proxy stage
-COPY --from=app-builder /usr/src/lazymc-docker-proxy/target/x86_64-unknown-linux-musl/release/lazymc-docker-proxy /usr/local/bin/lazymc-docker-proxy
+COPY --from=app-builder /usr/src/lazymc-docker-proxy/target/output_final/release/lazymc-docker-proxy /usr/local/bin/lazymc-docker-proxy
 
 # Copy the health init state
 COPY --from=health-init /app/health /app/health


### PR DESCRIPTION
This is a working implementation for adding arm64 support.

Fixes #122 

Good resources:
[docker CI setup](https://docs.docker.com/build/ci/github-actions/multi-platform/)
[multi-arch Dockerfile](https://docs.docker.com/build/building/multi-platform/)

Edit: 
This now builds in 6 minutes which is acceptable I think. It uses buildx to build the actual image but compiling is done in a regular x64 container by cross-compiling arm64.

Tested the resulting image on my private server, works as expected.