### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,9 @@ jobs:
     name: Find Tests
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     outputs:
       folders: ${{ steps.jobs.outputs.folders }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/joesturge/lazymc-docker-proxy/security/code-scanning/1](https://github.com/joesturge/lazymc-docker-proxy/security/code-scanning/1)

Add an explicit `permissions` block so the `find-tests` job does not inherit potentially broad defaults.

Best single fix with minimal behavior change in this file: add job-level permissions to `find-tests`:

- File: `.github/workflows/push.yml`
- Region: inside `jobs.find-tests`, after `runs-on` and before `outputs`
- Add:
  - `permissions:`
  - `contents: read`

This is sufficient for the current steps (`actions/checkout` and listing folders) and does not alter existing job logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
